### PR TITLE
Pulse-7087 - Adjust courier telegram media errors to return 200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM golang:latest as builder
+
+WORKDIR /app
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o courier ./cmd/courier/main.go
+
+
+
+FROM alpine:3.7
+
+ENV USER=courier
+ENV UID=13337
+ENV GID=13337
+
+RUN addgroup -g "$GID" "$USER" \
+    && adduser \
+    -D \
+    -g "" \
+    -h "$(pwd)" \
+    -G "$USER" \
+    -H \
+    -u "$UID" \
+    "$USER"
+
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+
+WORKDIR /app
+
+COPY --from=builder /app/courier .
+
+EXPOSE 8080
+
+USER courier
+
+ENTRYPOINT []
+CMD ["/app/courier"]

--- a/handlers/telegram/telegram.go
+++ b/handlers/telegram/telegram.go
@@ -118,12 +118,13 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// we had an error downloading media
 	if err != nil {
-		if !strings.Contains(err.Error(), "status: 400") {
-			return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.WrapPrefix(err, "error retrieving media", 0))
+		if strings.Contains(err.Error(), "status: 400") {
+			w.WriteHeader(200)
+
+			return nil, fmt.Errorf("Could not download attachments")
 		}
-		
-		msg := h.Backend().NewIncomingMsg(channel, urn, "Could not download media").WithReceivedOn(date).WithExternalID(fmt.Sprintf("%d", payload.Message.MessageID)).WithContactName(name)
-		return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r)
+
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.WrapPrefix(err, "error retrieving media", 0))
 	} 
 
 	msg := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(fmt.Sprintf("%d", payload.Message.MessageID)).WithContactName(name)

--- a/handlers/telegram/telegram.go
+++ b/handlers/telegram/telegram.go
@@ -118,13 +118,9 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 
 	// we had an error downloading media
 	if err != nil {
-		if strings.Contains(err.Error(), "status: 400") {
-			w.WriteHeader(200)
+		w.WriteHeader(200)
 
-			return nil, fmt.Errorf("Could not download attachments")
-		}
-
-		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, errors.WrapPrefix(err, "error retrieving media", 0))
+		return nil, fmt.Errorf("Could not download attachments")
 	} 
 
 	msg := h.Backend().NewIncomingMsg(channel, urn, text).WithReceivedOn(date).WithExternalID(fmt.Sprintf("%d", payload.Message.MessageID)).WithContactName(name)

--- a/handlers/telegram/telegram.go
+++ b/handlers/telegram/telegram.go
@@ -128,7 +128,6 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 	if mediaURL != "" {
 		msg.WithAttachment(mediaURL)
 	}
-
 	// and finally write our message
 	return handlers.WriteMsgsAndResponse(ctx, h, []courier.Msg{msg}, w, r)
 }


### PR DESCRIPTION
## Changes

When courier hits a media error (file too big, etc) on telegram it would return a generic 400 error. Unfortunately telegram would then resend the file over, and over, and over again until it got a 200. 

On top of that, Courier also makes it difficult to manually insert a `channel_error` and return a custom status code for channel errors using the default mechanism. They force error codes. 

So, we are bypassing that with a bit of a hack - by manually sending the 200 header before courier sends anything (go will prevent any subsequent status header), and sending back a basic Go error for courier's server to pickup and create the `channel_error` entry using it's built-in mechanism. 

## Testing

- Setup RP and Courier
- Setup a Telegram bot and connect it on RP
- Send various files sizes (100KB, 3 MB, 20MB, etc). Only attachments above 20 MB should trigger an error. 