### PR TITLE
P4-1496 - Change API key header, adjust scheme based on mode, better phone number formatting

### DIFF
--- a/handlers/postmaster/postmaster.go
+++ b/handlers/postmaster/postmaster.go
@@ -76,7 +76,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		scheme = urns.TelScheme
 
 		// Remove out + and - just in case
-		value := payload.Contact.Urn
+		value := payload.Contact.Value
 		value = strings.Replace(value, " ","",-1)
 		value = strings.Replace(value, "-","",-1)
 
@@ -84,12 +84,12 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		if len(value) > 8 {
 			isNumeric := regexp.MustCompile(`^[0-9 ]+$`).MatchString
 
-			if isNumeric(payload.Contact.Urn) {
+			if isNumeric(value) {
 				value = "+" + value
 			}
 		}
 
-		payload.Contact.Urn = value
+		payload.Contact.Value = value
 	case "WA":
 		scheme = PM_WHATSAPP_SCHEME
 	case "TG":
@@ -100,7 +100,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("invalid chat mode %s", mode))
 	}
 
-	urn, err = urns.NewURNFromParts(scheme, payload.Contact.Urn, "", "")
+	urn, err = urns.NewURNFromParts(scheme, payload.Contact.Value, "", "")
 
 	if err != nil {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
@@ -161,7 +161,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 	for _, part := range parts {
 		payload := outgoingMessage{}
 		payload.Contact.Name = msg.ContactName() //as of writing, this is always blank. :shrug:
-		payload.Contact.Urn = msg.URN().Path()
+		payload.Contact.Value = msg.URN().Path()
 		payload.Text = part
 		payload.Mode = strings.ToUpper(chatMode)
 		payload.ChannelID = msg.Channel().UUID().String()
@@ -229,7 +229,7 @@ Content-Type: application/json; charset=utf-8
 	"text": "bla",
 	"contact": {
 		"name": "Bob",
-		"urn": "tel:+11234567890"
+		"value": "tel:+11234567890"
 	},
 	"mode": "sms",
 	"channel_id": "7cc23772-e933-47b4-b025-19cbaec01edf",
@@ -242,7 +242,7 @@ type incomingMessage struct {
 	Text      string `json:"text" validate:"required"`
 	Contact struct {
 		Name string `json:"name"`
-		Urn  string `json:"urn" validate:"required"`
+		Value  string `json:"value" validate:"required"`
 	} `json:"contact" validate:"required"`
 	Mode      string `json:"mode" validate:"required"`
 	ChannelID string `json:"channel_id" validate:"required"`
@@ -255,7 +255,7 @@ type incomingMessage struct {
 	"text": "bla",
 	"contact": {
 		"name": "Bob",
-		"urn": "tel:+11234567890"
+		"value": "tel:+11234567890"
 	},
 	"mode": "sms",
 	"channel_id": "7cc23772-e933-47b4-b025-19cbaec01edf",
@@ -268,7 +268,7 @@ type outgoingMessage struct {
 	Text      string `json:"text" validate:"required"`
 	Contact struct {
 		Name string `json:"name"`
-		Urn  string `json:"urn" validate:"required"`
+		Value  string `json:"value" validate:"required"`
 	} `json:"contact" validate:"required"`
 	Mode      string `json:"mode" validate:"required"`
 	DeviceID  string `json:"device_id" validate:"required"`

--- a/handlers/postmaster/postmaster_test.go
+++ b/handlers/postmaster/postmaster_test.go
@@ -27,7 +27,7 @@ var acceptedMessage = `
 	"text": "bla",
 	"contact": {
 		"name": "Bob",
-		"urn": "+11234567890"
+		"value": "+11234567890"
 	},
 	"mode": "sms",
 	"channel_id": "08ecc21a-8098-4ddb-a090-eca7ee97f65d",
@@ -68,7 +68,7 @@ var defaultSendTestCases = []ChannelSendTestCase{
 		Text: "Simple Message ☺", URN: "tel:+11234567890", Attachments: []string{"image/jpeg:https://foo.bar/image.jpg"},
 		Status: "W",
 		ResponseBody: `{"ack":"ok","error":"","code":200}`, ResponseStatus: 200,
-		RequestBody: `{"text":"Simple Message ☺","contact":{"name":"","urn":"+11234567890"},"mode":"SMS","device_id":"123","channel_id":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","id":"10","media":["https://foo.bar/image.jpg"]}`,
+		RequestBody: `{"text":"Simple Message ☺","contact":{"name":"","value":"+11234567890"},"mode":"SMS","device_id":"123","channel_id":"8eb23e93-5ecb-45ba-b726-3b064e0c56ab","id":"10","media":["https://foo.bar/image.jpg"]}`,
 
 		SendPrep: setSendURL},
 }

--- a/handlers/postmaster/time.go
+++ b/handlers/postmaster/time.go
@@ -1,0 +1,36 @@
+package postmaster
+
+import (
+"fmt"
+"strings"
+"time"
+)
+
+type ISO8601WithMilli struct {
+	time.Time
+}
+
+const milliLayout = "2006-01-02T15:04:05.000Z"
+
+func (t *ISO8601WithMilli) UnmarshalJSON(b []byte) error {
+	var err error
+
+	s := strings.Trim(string(b), "\"")
+
+	if s == "null" || len(s) == 0 {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	t.Time, err = time.Parse(milliLayout, s)
+
+	return err
+}
+
+func (t *ISO8601WithMilli) MarshalJSON() ([]byte, error) {
+	if t.Time.UnixNano() == (time.Time{}).UnixNano() {
+		return []byte("null"), nil
+	}
+
+	return []byte(fmt.Sprintf("\"%s\"", t.Time.Format(milliLayout))), nil
+}


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
- Adjusted the PO API key header to use x-api-key
- For incoming messages, the scheme will be set per mode
- Full phone numbers will be prepended with a `+`, other numbers (shortcodes) will be left as is. 

#### Release Note
N/A

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [x] You have a log message clearly identifying when this feature is **working successfully**
- [x] You have a log message clearly identifying when this feature is **failing**

## Testing and Verification

1. `$ go test ./handlers/postmaster/.`
```
ok      github.com/nyaruka/courier/handlers/postmaster  0.428s
```
2. Setup a 4.0.2-dev stack, with a configured PM channel
3. `$ go run cmd/courier/main.go`
4. Using postman/curl, send a test incoming message to the handler:
`http://localhost:8080/c/psm/{YOUR_CHANNEL_ID}/receive`
```
{
	"time": "2020-04-22T12:01:02.123Z",
	"text": "bla",
	"contact": {
		"name": "Bob",
		"value": "+11234567890"
	},
	"mode": "sms",
	"channel_id": "{YOUR_CHANNEL_ID}",
	"media": []
}
```

You will get back a `Message Accepted` message. 