### PR TITLE
P4-1513 - Fix custom schemes, null field issue

### DIFF
--- a/handlers/postmaster/postmaster.go
+++ b/handlers/postmaster/postmaster.go
@@ -52,6 +52,10 @@ func newHandler() courier.ChannelHandler {
 
 // Initialize is called by the engine once everything is loaded
 func (h *handler) Initialize(s courier.Server) error {
+	urns.ValidSchemes[PM_WHATSAPP_SCHEME] = true
+	urns.ValidSchemes[PM_TELEGRAM_SCHEME] = true
+	urns.ValidSchemes[PM_LINE_SCHEME] = true
+
 	h.SetServer(s)
 	s.AddHandlerRoute(h, http.MethodPost, "receive", h.receiveMessage)
 	s.AddHandlerRoute(h, http.MethodPost, "status", h.receiveStatus)
@@ -118,7 +122,7 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 }
 
 func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w http.ResponseWriter, r *http.Request) ([]courier.Event, error) {
-	payload := &messageStatus{}
+	payload := new(messageStatus)
 	err := handlers.DecodeAndValidateJSON(payload, r)
 	if err != nil {
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
@@ -159,7 +163,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 
 	parts := handlers.SplitMsg(msg.Text(), maxMsgLength)
 	for _, part := range parts {
-		payload := outgoingMessage{}
+		payload := new(outgoingMessage)
 		payload.Contact.Name = msg.ContactName() //as of writing, this is always blank. :shrug:
 		payload.Contact.Value = msg.URN().Path()
 		payload.Text = part

--- a/handlers/postmaster/time.go
+++ b/handlers/postmaster/time.go
@@ -17,7 +17,7 @@ func (t *ISO8601WithMilli) UnmarshalJSON(b []byte) error {
 
 	s := strings.Trim(string(b), "\"")
 
-	if s == "null" || len(s) == 0 {
+	if s == "0" || len(s) == 0 {
 		t.Time = time.Time{}
 		return nil
 	}
@@ -29,7 +29,7 @@ func (t *ISO8601WithMilli) UnmarshalJSON(b []byte) error {
 
 func (t *ISO8601WithMilli) MarshalJSON() ([]byte, error) {
 	if t.Time.UnixNano() == (time.Time{}).UnixNano() {
-		return []byte("null"), nil
+		return []byte("0"), nil
 	}
 
 	return []byte(fmt.Sprintf("\"%s\"", t.Time.Format(milliLayout))), nil

--- a/handlers/postmaster/time.go
+++ b/handlers/postmaster/time.go
@@ -18,7 +18,7 @@ func (t *ISO8601WithMilli) UnmarshalJSON(b []byte) error {
 	s := strings.Trim(string(b), "\"")
 
 	if s == "0" || len(s) == 0 {
-		t.Time = time.Time{}
+		t.Time = time.Now().UTC()
 		return nil
 	}
 
@@ -29,7 +29,7 @@ func (t *ISO8601WithMilli) UnmarshalJSON(b []byte) error {
 
 func (t *ISO8601WithMilli) MarshalJSON() ([]byte, error) {
 	if t.Time.UnixNano() == (time.Time{}).UnixNano() {
-		return []byte("0"), nil
+		t.Time = time.Now().UTC()
 	}
 
 	return []byte(fmt.Sprintf("\"%s\"", t.Time.Format(milliLayout))), nil


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Incoming messages with custom schemes will no longer be blocked due to scheme validation. Previously null fields will be set with logical defaults. 

#### Release Note
N/A

#### Breaking Changes
None

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**


## Testing and Verification

## Testing and Verification

1. `$ go test ./handlers/postmaster/.`
```
ok      github.com/nyaruka/courier/handlers/postmaster  0.428s
```
2. Setup a 4.0.2-dev stack, with a configured PM channel
3. `$ go run cmd/courier/main.go`
4. Using postman/curl, send a test incoming message to the handler:
`http://localhost:8080/c/psm/{YOUR_CHANNEL_ID}/receive`
```
{
	"time": "2020-04-22T12:01:02.123Z",
	"text": "bla",
	"contact": {
		"name": "Bob",
		"value": "+11234567890"
	},
	"mode": "sms",
	"channel_id": "{YOUR_CHANNEL_ID}",
	"media": []
}
```

You will get back a `Message Accepted` message. 