### PR TITLE
P4-1569 - 4.0.2 Fix - Require either text and/or media

### DIFF
--- a/handlers/postmaster/postmaster.go
+++ b/handlers/postmaster/postmaster.go
@@ -63,6 +63,10 @@ func (h *handler) receiveMessage(ctx context.Context, channel courier.Channel, w
 		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, err)
 	}
 
+	if len(strings.Trim(payload.Text, " ")) == 0 && len(payload.Media) == 0 {
+		return nil, handlers.WriteAndLogRequestError(ctx, h, channel, w, r, fmt.Errorf("no message content provided"))
+	}
+
 	var urn urns.URN
 	mode := strings.ToUpper(payload.Mode)
 
@@ -233,7 +237,7 @@ Content-Type: application/json; charset=utf-8
 
 type incomingMessage struct {
 	Time      ISO8601WithMilli    `json:"time" validate:"required"`
-	Text      string `json:"text" validate:"required"`
+	Text      string `json:"text"`
 	Contact struct {
 		Name string `json:"name"`
 		Value  string `json:"value" validate:"required"`


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Incoming messages will require either text and/or media. If neither exist, an error will be raised. 

#### Release Note
Errors will be raised only when both text or media are missing from incoming postmaster messages. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Setup a full engage 4.0.2 stack.
2. Setup a postmaster channel
3. Use postmaster to relay an invalid incoming message, or alternatively use curl:
```
curl --location --request POST 'http://localhost:8080/c/psm/a62cb90f-a83c-4d5c-9cc1-996bf594a8fe/receive' \
--header 'Content-Type: application/json' \
--data-raw '{
	"time": "2020-04-22T12:01:02.123Z",
	"text": "",
	"contact": {
		"name": "Bob",
		"value": "+11234567890"
	},
	"mode": "sms",
	"channel_id": "e3522a97-eb9e-451f-ac4d-848d2ad5c8f6",
	"media": []
}'
```
response:
```
{
    "message": "Error",
    "data": [
        {
            "type": "error",
            "error": "no message content provided"
        }
    ]
}
```
Confirm that valid messages (with text/media, or both) still work as expected. 