### PR TITLE
P4-1611 - Set initial status as pending so it stays in the outbox.

### DIFF
--- a/handlers/postmaster/postmaster.go
+++ b/handlers/postmaster/postmaster.go
@@ -193,7 +193,7 @@ func (h *handler) SendMsg(ctx context.Context, msg courier.Msg) (courier.MsgStat
 		}
 	}
 
-	status.SetStatus(courier.MsgWired)
+	status.SetStatus(courier.MsgPending)
 
 	return status, nil
 }


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Postmaster messages will remain in the outbox after courier handles it. The channel will reply with a sent status when it is actually handled. 

#### Release Note
Postmaster messages will remain in the outbox after courier handles it. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Create an `Engage 4.0.3` stack
2. Add a postmaster channel
3. Send an outgoing message. It will remain in the outbox. 
