### PR TITLE
P4-1934 - Purge outgoing queue endpoint

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -74,6 +74,12 @@ type Backend interface {
 	// implement their own logic to implement this.
 	IsMsgLoop(ctx context.Context, msg Msg) (bool, error)
 
+	// Loops through the active and throttled queues to find the current queue keys for a specific channel
+	GetCurrentQueuesForChannel(context.Context, ChannelUUID) ([]string, error)
+
+	// Pops n messages from a queue without checking if the message is able to be popped, if there is throttling, etc.
+	PopMsgs(context.Context, string, int) ([]Msg, error)
+
 	// MarkOutgoingMsgComplete marks the passed in message as having been processed. Note this should be called even in the case
 	// of errors during sending as it will manage the number of active workers per channel. The optional status parameter can be
 	// used to determine any sort of deduping of msg sends

--- a/purge.go
+++ b/purge.go
@@ -1,0 +1,74 @@
+package courier
+
+import (
+	"context"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+type PurgeHandler struct {
+	server Server
+}
+
+func NewPurgeHandler(s Server) *PurgeHandler{
+	p := new(PurgeHandler)
+	p.server = s
+
+	return p
+}
+
+func (p *PurgeHandler) PurgeChannel(w http.ResponseWriter, r *http.Request) {
+	//uuid, err := NewChannelUUID("b2a8151e-5d21-42e6-8077-3abcf9e38173")
+	uuid, err := NewChannelUUID("b2a8151e-5d21-42e6-8077-3abcf9e38173")
+
+	if err != nil {
+		logrus.Error("Invalid channel ID provided")
+		return
+	}
+
+	queues, err := p.server.Backend().GetCurrentQueuesForChannel(context.Background(), uuid)
+
+	if err != nil {
+		logrus.Error(err)
+	} else if len(queues) == 0 {
+		logrus.Info("No queues found")
+	}
+
+	p.PurgeRoutine(queues)
+}
+
+func (p *PurgeHandler) PurgeRoutine(queueKeys []string) {
+	rc := p.server.Backend().RedisPool().Get()
+	defer rc.Close()
+
+	// Iterate throuhg each queue for the channel, then iterate messages
+	for _, v := range queueKeys {
+		logrus.Info(v)
+
+		hasMsg := true
+		// Iterate through messages until we're out of them.
+		for hasMsg == true {
+			msgs, _ := p.server.Backend().PopMsgs(context.Background(), v, 1)
+
+			if len(msgs) == 0 {
+				logrus.Debug("out of messages")
+				hasMsg = false
+				break
+			}
+
+			for _, msg := range msgs {
+				status := p.server.Backend().NewMsgStatusForID(msg.Channel(), msg.ID(), MsgFailed)
+				status.AddLog(NewChannelLogFromError("Queue Purge", msg.Channel(), msg.ID(), 0,
+					fmt.Errorf("failing message due to purge")))
+
+				err := p.server.Backend().WriteMsgStatus(context.Background(), status)
+				if err != nil {
+					logrus.WithError(err).Info("error writing msg status")
+				} else {
+					logrus.WithField("msg", msg.ID()).Info("Failing message due to queue purge")
+				}
+			}
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -109,7 +109,8 @@ func (s *server) Start() error {
 	s.router.Get("/status", s.handleStatus)
 
 	p := NewPurgeHandler(s)
-	p.PurgeChannel(nil, nil)
+
+	s.router.Post("/purge/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}", p.PurgeChannel)
 
 	// initialize our handlers
 	s.initializeChannelHandlers()

--- a/server.go
+++ b/server.go
@@ -108,6 +108,9 @@ func (s *server) Start() error {
 	s.router.Get("/", s.handleIndex)
 	s.router.Get("/status", s.handleStatus)
 
+	p := NewPurgeHandler(s)
+	p.PurgeChannel(nil, nil)
+
 	// initialize our handlers
 	s.initializeChannelHandlers()
 

--- a/test.go
+++ b/test.go
@@ -368,6 +368,18 @@ func (mb *MockBackend) RedisPool() *redis.Pool {
 	return mb.redisPool
 }
 
+func (mb *MockBackend) PurgeOutgoingQueue(channelID string) error {
+	return nil
+}
+
+func (mb *MockBackend) GetCurrentQueuesForChannel(ctx context.Context, uuid ChannelUUID) ([]string, error) {
+	return nil, nil
+}
+
+func (mb *MockBackend)  PopMsgs(ctx context.Context, queueKey string, count int) ([]Msg, error) {
+	return nil, nil
+}
+
 func buildMockBackend(config *Config) Backend {
 	return NewMockBackend()
 }


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Added a `/purge` endpoint to courier to start a purge of all outgoing messages for a given channel. Due to courier's asynchronous nature, not all messages can be purged before they are sent, but it should be able to catch most of them. 

#### Release Note
Added an endpoint to perform a purge of outgoing messages currently queued for a specific channel. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Start an engage 4.0.4-dev stack
2. Setup a channel. For testing I suggest using a dummy channel with bad credentials so you don't accidentally sent hundreds of messages. 
3. Open a terminal and call the purge endpoint 
```
curl --location --request POST 'http://localhost:8080/purge/CHANNEL_ID'  --header 'Content-Type: application/json' 
```
4. You should get back a 200 with the following message: `{"message":"No outgoing queues found","data":null}
`
5. From the UI, bulk-send a large number of messages (hundreds)
6. Quickly switch back  to the terminal and call the endpoint again, you should get back a 200 with:
`{"message":"Ok","data":null}`
7. After a few seconds, confirm that most of the messages are no longer in the `outbox` and instead show as `failed` on the UI