### PR TITLE
P4-1976 - Rename queue prior to purge, resume purges on courier crash. 

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -74,8 +74,14 @@ type Backend interface {
 	// implement their own logic to implement this.
 	IsMsgLoop(ctx context.Context, msg Msg) (bool, error)
 
+	// Gets a list of all active purges
+	GetActivePurges(context.Context) ([]string, error)
+
 	// Loops through the active and throttled queues to find the current queue keys for a specific channel
 	GetCurrentQueuesForChannel(context.Context, ChannelUUID) ([]string, error)
+
+	// Prepares a list of queues for a purge by renaming them and adding them to the active purge list
+	PrepareQueuesForPurge(context.Context, []string) ([]string, error)
 
 	// Pops n messages from a queue without checking if the message is able to be popped, if there is throttling, etc.
 	PopMsgs(context.Context, string, int) ([]Msg, error)

--- a/purge.go
+++ b/purge.go
@@ -73,7 +73,7 @@ func (p *PurgeHandler) PurgeRoutine(queueKeys []string) {
 
 	// Iterate throuhg each queue for the channel, then iterate messages
 	for _, v := range queueKeys {
-		logrus.Info(v)
+		logrus.WithField("queue", v).Info("Purging queue")
 
 		hasMsg := true
 		// Iterate through messages until we're out of them.

--- a/purge.go
+++ b/purge.go
@@ -40,9 +40,31 @@ func (p *PurgeHandler) PurgeChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go p.PurgeRoutine(queues)
+	purgeQueues, err := p.server.Backend().PrepareQueuesForPurge(context.Background(), queues)
+
+	if err != nil {
+		logrus.Error(err)
+		WriteDataResponse(context.Background(), w, http.StatusInternalServerError,
+			"Error while preparing queues for purge", nil)
+		return
+	}
+
+	go p.PurgeRoutine(purgeQueues)
 
 	WriteDataResponse(context.Background(), w, http.StatusOK, "Ok", nil)
+}
+
+func (p PurgeHandler) ResumePurges() {
+	purgeQueues, err := p.server.Backend().GetActivePurges(context.Background())
+
+	if err == nil && len(purgeQueues) == 0 {
+		logrus.Debug("No purges to resume")
+	} else if err != nil {
+		logrus.WithError(err).Error("Could not resume purges")
+	} else {
+		logrus.WithField("queues", purgeQueues).Debug("Resuming purge")
+		go p.PurgeRoutine(purgeQueues)
+	}
 }
 
 func (p *PurgeHandler) PurgeRoutine(queueKeys []string) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,7 +1,9 @@
 package queue
 
 import (
+	"errors"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -263,6 +265,10 @@ func StartDethrottler(redis *redis.Pool, quitter chan bool, wg *sync.WaitGroup, 
 	}()
 }
 
+func GetActivePurges(conn redis.Conn) ([]string, error) {
+	return redis.Strings(conn.Do("LRANGE", "msgs:active_purge", "0", "-1"))
+}
+
 func GetAllChannelQueues(conn redis.Conn, channelID string) ([]string, error) {
 	ret, err := redis.StringMap(luaGetAllChannelQueues.Do(conn, channelID))
 
@@ -304,6 +310,16 @@ var luaGetAllChannelQueues = redis.NewScript(1, `-- KEYS: [ChannelID]
 	until cursor == "0";
 
 	repeat
+		local result = redis.call("ZSCAN", "msgs:future", cursor, "MATCH", "msgs:" .. KEYS[1] .. "*", "COUNT", "100");
+
+		cursor = result[1];
+
+		for _, v in ipairs(result[2]) do
+          list[#list+1] = v
+		end;
+	until cursor == "0";
+
+	repeat
 		local result = redis.call("ZSCAN", "msgs:active", cursor, "MATCH", "msgs:" .. KEYS[1] .. "*", "COUNT", "100");
 
 		cursor = result[1];
@@ -319,5 +335,42 @@ var luaGetAllChannelQueues = redis.NewScript(1, `-- KEYS: [ChannelID]
 func PopWithoutChecks(conn redis.Conn, queue string, count int) (map[string]string, error) {
 	ret, err := redis.StringMap(conn.Do("ZPOPMIN", queue, count))
 
+	// Remove entry from purge queue if message queue is empty
+	if err == nil && len(ret) == 0 {
+		redis.Int(conn.Do("LREM", "msgs:active_purge", "0", queue))
+	}
+
 	return ret, err
+}
+
+func PrepareQueueForPurge(conn redis.Conn, queue string) (string, error) {
+	exists, err := redis.Int(conn.Do("EXISTS", queue))
+
+	if err != nil {
+		return "", err
+	}
+
+	if exists != 1 {
+		return "", err
+	}
+
+	newName := "msgs:purge:" + queue
+
+	rename, err := redis.String(conn.Do("RENAME", queue, newName))
+
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(rename, "OK") {
+		return "", errors.New("could not rename queue: " + rename)
+	}
+
+	_, err = redis.Int(conn.Do("LPUSH", "msgs:active_purge", newName))
+
+	if err != nil {
+		return "", errors.New("could not add queue to active purge list: " + newName)
+	}
+
+	return newName, nil
 }

--- a/server.go
+++ b/server.go
@@ -109,6 +109,7 @@ func (s *server) Start() error {
 	s.router.Get("/status", s.handleStatus)
 
 	p := NewPurgeHandler(s)
+	p.ResumePurges()
 
 	s.router.Post("/purge/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}", p.PurgeChannel)
 

--- a/test.go
+++ b/test.go
@@ -372,7 +372,15 @@ func (mb *MockBackend) PurgeOutgoingQueue(channelID string) error {
 	return nil
 }
 
+func (mb *MockBackend) GetActivePurges(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+
 func (mb *MockBackend) GetCurrentQueuesForChannel(ctx context.Context, uuid ChannelUUID) ([]string, error) {
+	return nil, nil
+}
+
+func (mb * MockBackend) PrepareQueuesForPurge(ctx context.Context, queues []string) ([]string, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
When a purge is initiated, the outgoing queues will be renamed so courier stops all processing of them. The queue names are added to a `msgs:active_purge` list, and the queues themself are renamed like `msgs:purge:OLD_NAME`. When courier boots up it will check the active_purge list to ensure there were no purges being processed during shutdown. 

#### Release Note
The outgoing queue will be renamed prior to a purge, to prevent courier from doing any further processing of the message. Additionally, courier will resume purges on restart. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Start an engage 4.0.4-dev stack
2. Setup a channel. For testing I suggest using a dummy channel with bad credentials so you don't accidentally sent hundreds of messages. 
3. Open a terminal and call the purge endpoint 
```
curl --location --request POST 'http://localhost:8080/purge/CHANNEL_ID'  --header 'Content-Type: application/json' 
```
4. You should get back a 200 with the following message: `{"message":"No outgoing queues found","data":null}
`
5. From the UI, bulk-send a large number of messages (hundreds)
6. Quickly switch back  to the terminal and call the endpoint again, you should get back a 200 with:
`{"message":"Ok","data":null}`
7. After a few seconds, confirm that most of the messages are no longer in the `outbox` and instead show as `failed` on the UI

To test resuming:

1. Follow the instructions above, but during the purge terminate courier. cntrl+c tends to be slow, so you may need to kill it via `kill -9 PID` (if running via docker, disable the restart policy for courier!)
2. Via redis-cli or commander, confirm that the `msgs:active_purge` key still exists.
3. Restart courier, the purge should continue as soon as it boots back up. 