### PR TITLE
P4-1998 - Randomize queue name prior to purge

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -64,6 +64,10 @@ func (h *dummyHandler) receiveMsg(ctx context.Context, channel Channel, w http.R
 	return []Event{msg}, nil
 }
 
+func (h *dummyHandler) PurgeOutgoing(ctx context.Context, channel Channel) error {
+	return nil
+}
+
 func testConfig() *Config {
 	config := NewConfig()
 	config.DB = "postgres://courier:courier@localhost:5432/courier_test?sslmode=disable"

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"errors"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -277,7 +278,7 @@ func GetAllChannelQueues(conn redis.Conn, channelID string) ([]string, error) {
 	}
 
 	keys := make([]string, 0)
-	for k,_ := range ret {
+	for k, _ := range ret {
 		keys = append(keys, k)
 	}
 
@@ -354,7 +355,9 @@ func PrepareQueueForPurge(conn redis.Conn, queue string) (string, error) {
 		return "", err
 	}
 
-	newName := "msgs:purge:" + queue
+	rndAppend := strconv.FormatInt(rand.Int63n(9001), 10)
+
+	newName := "msgs:purge:" + queue + "|" + rndAppend
 
 	rename, err := redis.String(conn.Do("RENAME", queue, newName))
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
To help prevent the queue from being overwritten in the event of quick purges, the queue name will now be appended with a randomized string prior to the purge. 

#### Release Note
Queue names will be appended with a randomized string prior to purge. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Start an engage 4.0.5-dev stack: `docker-compose up -d`
2. Add a channel and generate at least a hundred messages. Easiest way to do this is via  a large contact group. 
3. Click purge outbox
4. Check the logs for courier - The purge log should look similar to this:
```
INFO[0001] Purging queue                                 queue="msgs:purge:msgs:c904f425-3c97-46c3-b46b-211b106514c8|10/0|1217"
```
Note the extra bar at the end of the queue name (1217 in this example) - that is the random string appended. 