### PR TITLE
P4-1664 - Grab contact name during outgoing postmaster messages

### DIFF
--- a/purge.go
+++ b/purge.go
@@ -30,7 +30,6 @@ func (p *PurgeHandler) PurgeChannel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	channelType := ChannelType(strings.ToUpper(chi.URLParam(r, "type")))
-
 	channel, err := p.server.Backend().GetChannel(r.Context(), channelType, uuid)
 
 	if channel == nil || err != nil {

--- a/purge_test.go
+++ b/purge_test.go
@@ -1,0 +1,58 @@
+package courier
+
+import (
+	"fmt"
+	"github.com/nyaruka/courier/queue"
+	"github.com/nyaruka/courier/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestPurgeHandler_PurgeChannel(t *testing.T) {
+	logger := logrus.New()
+	config := NewConfig()
+	backend := NewMockBackend()
+	dmChannel := NewMockChannel("e4bb1578-29da-4fa5-a214-9da19dd24230",
+		"DM", "123", "US",
+		make(map[string]interface{}))
+	backend.AddChannel(dmChannel)
+
+	server := NewServerWithLogger(config, backend, logger)
+	server.Start()
+	defer server.Stop()
+
+	// wait for server to come up
+	time.Sleep(100 * time.Millisecond)
+
+	//test no queue
+	req, _ := http.NewRequest("POST", "http://localhost:8080/purge/dm/e4bb1578-29da-4fa5-a214-9da19dd24230", nil)
+	rr, err := utils.MakeHTTPRequest(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rr.StatusCode)
+	assert.JSONEq(t, `{"message":"Ok","data":null}`, string(rr.Body), "Incorrect response returned")
+
+	rate := 50
+	conn := backend.RedisPool().Get()
+	defer conn.Close()
+
+	// Queue 20 messages
+	for i := 0; i < 20; i++ {
+		err := queue.PushOntoQueue(conn, "msgs", "e4bb1578-29da-4fa5-a214-9da19dd24230", rate, fmt.Sprintf(`[{"id":%d}]`, i), queue.LowPriority)
+		assert.NoError(t, err)
+	}
+
+	// Ensure all 20 were added
+	cnt, err := conn.Do("ZCOUNT", "msgs:e4bb1578-29da-4fa5-a214-9da19dd24230|50/0", "-inf", "+inf")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(20), cnt)
+
+	//test no queue
+	req, _ = http.NewRequest("POST", "http://localhost:8080/purge/dm/e4bb1578-29da-4fa5-a214-9da19dd24230", nil)
+	rr, err = utils.MakeHTTPRequest(req)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, rr.StatusCode)
+	assert.JSONEq(t, `{"message":"Ok","data":null}`, string(rr.Body), "Incorrect response returned")
+}

--- a/purge_test.go
+++ b/purge_test.go
@@ -11,6 +11,10 @@ import (
 	"time"
 )
 
+type testThing  struct {
+	name string
+}
+
 func TestPurgeHandler_PurgeChannel(t *testing.T) {
 	logger := logrus.New()
 	config := NewConfig()
@@ -40,7 +44,8 @@ func TestPurgeHandler_PurgeChannel(t *testing.T) {
 
 	// Queue 20 messages
 	for i := 0; i < 20; i++ {
-		err := queue.PushOntoQueue(conn, "msgs", "e4bb1578-29da-4fa5-a214-9da19dd24230", rate, fmt.Sprintf(`[{"id":%d}]`, i), queue.LowPriority)
+		msgData := fmt.Sprintf(`[{"id":%d, "channelid": "e4bb1578-29da-4fa5-a214-9da19dd24230"}]`, i)
+		err := queue.PushOntoQueue(conn, "msgs", "e4bb1578-29da-4fa5-a214-9da19dd24230", rate, msgData, queue.LowPriority)
 		assert.NoError(t, err)
 	}
 
@@ -49,10 +54,17 @@ func TestPurgeHandler_PurgeChannel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(20), cnt)
 
-	//test no queue
+	//test purge
 	req, _ = http.NewRequest("POST", "http://localhost:8080/purge/dm/e4bb1578-29da-4fa5-a214-9da19dd24230", nil)
 	rr, err = utils.MakeHTTPRequest(req)
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, rr.StatusCode)
 	assert.JSONEq(t, `{"message":"Ok","data":null}`, string(rr.Body), "Incorrect response returned")
+
+	time.Sleep(time.Second * 1)
+
+	// Ensure there's no messages left
+	cnt, err = conn.Do("ZCOUNT", "msgs:e4bb1578-29da-4fa5-a214-9da19dd24230|50/0", "-inf", "+inf")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), cnt)
 }


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
The contact name will be fetched when outgoing postmaster messages are handled. 

#### Release Note
Courier will now provide the contact name to outgoing postmaster messages. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. `docker-compose up -d -- build`
2. Send an outgoing message over a postmaster channel, using a contact with a name set.
3. Confirm via postoffice that the message was sent with the contact name. 