### PR TITLE
PE-133: Add support for message timeouts to PM channel

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -94,6 +94,9 @@ type Backend interface {
 	// used to determine any sort of deduping of msg sends
 	MarkOutgoingMsgComplete(context.Context, Msg, MsgStatus)
 
+	// SetFlowSessionTimeoutByMsgId If the flow session for a given msg ID is waiting, set its timeout
+	SetFlowSessionTimeoutByMsgId(context.Context, MsgID) error
+
 	// Check if external ID has been seen in a period
 	CheckExternalIDSeen(Msg) Msg
 

--- a/backends/rapidpro/backend.go
+++ b/backends/rapidpro/backend.go
@@ -250,7 +250,7 @@ func (b *backend) MarkOutgoingMsgComplete(ctx context.Context, msg courier.Msg, 
 	}
 }
 
-// Joins the flow session and gets the last event of the last run and checks if it is a msg_wait event
+// Joins the flow session and gets the last event of the last run and checks if it is a msg_wait event and update timeout.
 const updateFlowSessionTimeoutByMsgID = `
 update flows_flowsession sess_orig 
 	set timeout_on=(NOW() + (sess.output::json->'runs'->-1->'events'->-1->>'timeout_seconds')::int * interval '1 second')

--- a/handlers/postmaster/postmaster.go
+++ b/handlers/postmaster/postmaster.go
@@ -6,18 +6,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-chi/chi"
+	"github.com/nyaruka/courier"
 	"github.com/nyaruka/courier/backends/rapidpro"
+	"github.com/nyaruka/courier/handlers"
+	"github.com/nyaruka/courier/utils"
+	"github.com/nyaruka/gocommon/urns"
 	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/nyaruka/courier"
-	"github.com/nyaruka/courier/handlers"
-	"github.com/nyaruka/courier/utils"
-	"github.com/nyaruka/gocommon/urns"
 
 	validator "gopkg.in/go-playground/validator.v9"
 )
@@ -173,7 +172,14 @@ func (h *handler) receiveStatus(ctx context.Context, channel courier.Channel, w 
 
 	cid, err := strconv.ParseInt(payload.MessageID, 10, 64)
 
-	status := h.Backend().NewMsgStatusForID(channel, courier.NewMsgID(cid), statusMapping[payload.Status])
+	courierStatus := statusMapping[payload.Status]
+	id := courier.NewMsgID(cid)
+
+	if courierStatus == courier.MsgSent {
+		_ = h.Backend().SetFlowSessionTimeoutByMsgId(ctx, id)
+	}
+
+	status := h.Backend().NewMsgStatusForID(channel, id, courierStatus)
 
 	return handlers.WriteMsgStatusAndResponse(ctx, h, channel, status, w, r)
 }

--- a/test.go
+++ b/test.go
@@ -177,6 +177,10 @@ func (mb *MockBackend) MarkOutgoingMsgComplete(ctx context.Context, msg Msg, s M
 	mb.sentMsgs[msg.ID()] = true
 }
 
+func (mb *MockBackend) SetFlowSessionTimeoutByMsgId(ctx context.Context, id MsgID) error {
+	return nil
+}
+
 // WriteChannelLogs writes the passed in channel logs to the DB
 func (mb *MockBackend) WriteChannelLogs(ctx context.Context, logs []*ChannelLog) error {
 	mb.mutex.Lock()


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
When PM returns back a sent or delivered status, courier will now set the message's flowsession's timeout_on field with a timeout so the "wait for message" feature within rapidpro will now function as expected for PM channels.  

This is handled via a postgres query which will peek at the JSON output field of the flow session to grab the timeout, and if the session is in (W)aiting state it will set the timeout. 

#### Release Note
The "Wait for Message" feature in rapidpro will now work for PM channels. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Create a simple flow with a message wait toggle turned on. 
2. Send to a contact
3. Wait for the timeout
4. The contact should now receive the follow up expiration message you have configured. 


<img width="808" alt="Screenshot 2023-09-14 at 8 31 11 AM" src="https://github.com/istresearch/courier/assets/25488234/5b584938-a990-4a30-90dd-1a55d1178c01">


<img width="1859" alt="Screenshot 2023-09-14 at 8 32 53 AM" src="https://github.com/istresearch/courier/assets/25488234/9b4ec959-a83d-4e33-b25b-03f972bbec51">
