### PR TITLE
Reimplement custom bucket url format, with a blank default.

### DIFF
--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -307,10 +307,6 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 
 	// Allow non-standard S3 URLs to be used.
 	if len(b.config.S3BucketUrlFormat) > 0 {
-		if !strings.HasPrefix(path, "/") {
-			path = fmt.Sprintf("/%s", path)
-		}
-
 		s3URL = fmt.Sprintf(b.config.S3BucketUrlFormat, b.config.S3MediaBucket) + path
 	}
 

--- a/backends/rapidpro/msg.go
+++ b/backends/rapidpro/msg.go
@@ -305,6 +305,15 @@ func downloadMediaToS3(ctx context.Context, b *backend, channel courier.Channel,
 		return "", err
 	}
 
+	// Allow non-standard S3 URLs to be used.
+	if len(b.config.S3BucketUrlFormat) > 0 {
+		if !strings.HasPrefix(path, "/") {
+			path = fmt.Sprintf("/%s", path)
+		}
+
+		s3URL = fmt.Sprintf(b.config.S3BucketUrlFormat, b.config.S3MediaBucket) + path
+	}
+
 	// return our new media URL, which is prefixed by our content type
 	return fmt.Sprintf("%s:%s", mimeType, s3URL), nil
 }

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	DB                        string `help:"URL describing how to connect to the RapidPro database"`
 	Redis                     string `help:"URL describing how to connect to Redis"`
 	SpoolDir                  string `help:"the local directory where courier will write statuses or msgs that need to be retried (needs to be writable)"`
+	S3BucketUrlFormat         string `help:"the url to the s3 bucket we will write attachments to, with one string placeholder for the bucket name"`
 	S3Endpoint                string `help:"the S3 endpoint we will write attachments to"`
 	S3Region                  string `help:"the S3 region we will write attachments to"`
 	S3MediaBucket             string `help:"the S3 bucket we will write attachments to"`
@@ -49,6 +50,7 @@ func NewConfig() *Config {
 		DB:                           "postgres://temba:temba@localhost/temba?sslmode=disable",
 		Redis:                        "redis://localhost:6379/15",
 		SpoolDir:                     "/var/spool/courier",
+		S3BucketUrlFormat:            "",
 		S3Endpoint:                   "https://s3.amazonaws.com",
 		S3Region:                     "us-east-1",
 		S3MediaBucket:                "courier-media",


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Reimplemented the custom URL format for S3 buckets, for non-standard S3 implementations. 

#### Release Note
Re-added `COURIER_S3_BUCKET_URL_FORMAT` to courier. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Setup and initialize your local instance using the rapidpro/workspace docker-compose. 
2. Send a message to courier with an attachment
3. The S3 URL via the  rapidpro UI should use the format you specify with the COURIER_S3_BUCKET_URL_FORMAT variable. 